### PR TITLE
Add predefined target platforms

### DIFF
--- a/lib/collections/projects/schema.js
+++ b/lib/collections/projects/schema.js
@@ -75,7 +75,16 @@ ProjectsSchema = new SimpleSchema({
   },
   "targetPlatforms": {
     type: [String],
-    label: "Target Platforms"
+    label: "Target Platforms",
+    allowedValues: ['web', 'ios', 'android', 'windows-phone'],
+    autoform: {
+      options: [
+        {label: "Web", value: "web"},
+        {label: "iOS", value: "ios"},
+        {label: "Android", value: "android"},
+        {label: "Windows Phone", value: "windows-phone"}
+      ]
+    }
   },
   "address": {
     type: String,

--- a/projects/add/client/addProject.html
+++ b/projects/add/client/addProject.html
@@ -23,6 +23,8 @@
 
     {{> afQuickField name="targetGroups" }}
 
+    {{> afQuickField name="targetPlatforms" }}
+
 
     <button type="submit" class="btn btn-primary">Submit Project</button>
   {{/ autoForm }}


### PR DESCRIPTION
This adds the predefined target platforms to projects (as discussed in Issue #28 ) and adds a form input element for the field.

This closes #28 
