### PR TITLE
adding class active to nav-bar

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -39,3 +39,4 @@ cfs:standard-packages
 cfs:gridfs
 cfs:autoform
 jeremy:selectize
+zimme:active-route

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -127,3 +127,4 @@ useraccounts:core@1.12.4
 useraccounts:unstyled@1.12.4
 webapp@1.2.3
 webapp-hashing@1.0.5
+zimme:active-route@2.3.2

--- a/main/client/header/navbar.html
+++ b/main/client/header/navbar.html
@@ -17,10 +17,11 @@
         </div>
         <div class="navbar-collapse collapse" id="rft-collapse-navbar">
             <ul class="text-uppercase navbar-left navbar-nav nav ">
-              <li><a href="#">What we do</a></li>
-              <li><a href="#">Knowledge Hub</a></li>
-              <li><a href="/projects">Projects</a></li>
-              <li><a href="#">Blog</a></li>
+             <!--When changing to proper links for "What we do", "Knowledge hub" and "Blog", please change the path in <li> to the same as in the corresponding href-->
+              <li class="{{isActivePath class='active' path='/#about'}}"><a href="/#about">What we do</a></li>
+              <li class="{{isActivePath class='active' path='/#knowledge'}}"><a href="/#knowledge">Knowledge Hub</a></li>
+              <li class="{{isActivePath class='active' path='/projects'}}"><a href="/projects">Projects</a></li>
+              <li class="{{isActivePath class='active' path='/#blog'}}"><a href=/#blog>Blog</a></li>
             </ul>
             <ul class="navbar-right navbar-nav nav">
               <li><a href="#"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span><span class="visible-lg-inline visible-xs-inline">English</span></a></li>


### PR DESCRIPTION
This is the last task for issue#71. Please note that only /projects works properly at the moment since there are no other "real" links. When links are added to "What we do", "Knowledge hub" and "Blog", please change the "path" in the `<li>` element to the same path as the link.
